### PR TITLE
Test with newer Python and pytest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# IDEs
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,132 +3,86 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOX_ENV=py27-pytest_27
+      env: TOX_ENV=py27-pytest_2
     - python: 2.7
-      env: TOX_ENV=py27-pytest_28
+      env: TOX_ENV=py27-pytest_3
     - python: 2.7
-      env: TOX_ENV=py27-pytest_29
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_32
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_33
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_34
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_35
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_36
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_37
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_38
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_39
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_310
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_40
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_41
-    - python: 2.7
-      env: TOX_ENV=py27-pytest_latest
-    
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_27
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_28
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_29
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_32
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_33
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_34
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_35
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_36
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_37
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_38
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_39
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_310
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_40
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_41
-    - python: 3.4
-      env: TOX_ENV=py34-pytest_latest
-    
+      env: TOX_ENV=py27-pytest_4
+
     - python: 3.5
-      env: TOX_ENV=py35-pytest_27
+      env: TOX_ENV=py35-pytest_2
     - python: 3.5
-      env: TOX_ENV=py35-pytest_28
+      env: TOX_ENV=py35-pytest_3
     - python: 3.5
-      env: TOX_ENV=py35-pytest_29
+      env: TOX_ENV=py35-pytest_4
     - python: 3.5
-      env: TOX_ENV=py35-pytest_32
+      env: TOX_ENV=py35-pytest_50
     - python: 3.5
-      env: TOX_ENV=py35-pytest_33
+      env: TOX_ENV=py35-pytest_51
     - python: 3.5
-      env: TOX_ENV=py35-pytest_34
+      env: TOX_ENV=py35-pytest_52
     - python: 3.5
-      env: TOX_ENV=py35-pytest_35
+      env: TOX_ENV=py35-pytest_53
     - python: 3.5
-      env: TOX_ENV=py35-pytest_36
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_37
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_38
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_39
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_310
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_40
-    - python: 3.5
-      env: TOX_ENV=py35-pytest_41
+      env: TOX_ENV=py35-pytest_54
     - python: 3.5
       env: TOX_ENV=py35-pytest_latest
-    
+
     - python: 3.6
-      env: TOX_ENV=py36-pytest_27
+      env: TOX_ENV=py36-pytest_2
     - python: 3.6
-      env: TOX_ENV=py36-pytest_28
+      env: TOX_ENV=py36-pytest_3
     - python: 3.6
-      env: TOX_ENV=py36-pytest_29
+      env: TOX_ENV=py36-pytest_4
     - python: 3.6
-      env: TOX_ENV=py36-pytest_32
+      env: TOX_ENV=py36-pytest_50
     - python: 3.6
-      env: TOX_ENV=py36-pytest_33
+      env: TOX_ENV=py36-pytest_51
     - python: 3.6
-      env: TOX_ENV=py36-pytest_34
+      env: TOX_ENV=py36-pytest_52
     - python: 3.6
-      env: TOX_ENV=py36-pytest_35
+      env: TOX_ENV=py36-pytest_53
     - python: 3.6
-      env: TOX_ENV=py36-pytest_36
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_37
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_38
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_39
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_310
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_40
-    - python: 3.6
-      env: TOX_ENV=py36-pytest_41
+      env: TOX_ENV=py36-pytest_54
     - python: 3.6
       env: TOX_ENV=py36-pytest_latest
+
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_3
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_4
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_50
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_51
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_52
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_53
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_54
+    - python: 3.7
+      env: TOX_ENV=py37-pytest_latest
+
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_3
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_4
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_50
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_51
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_52
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_53
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_54
+    - python: 3.8
+      env: TOX_ENV=py38-pytest_latest
 
 install:
   - pip install tox
 
 script:
   - tox -e $TOX_ENV
-  

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/test/test_marks.py
+++ b/test/test_marks.py
@@ -47,6 +47,7 @@ def test_keywords(testdir):
     result = testdir.runpytest('-k', 'foo')
     assert_outcomes(result, passed=1, deselected=1)
 
+
 def test_marks(testdir):
     a_dir = testdir.mkpydir('a_dir')
     a_dir.join('test_a.py').write(py.code.Source("""

--- a/test/util.py
+++ b/test/util.py
@@ -1,10 +1,8 @@
 def assert_outcomes(result, **expected):
-    o = result.parseoutcomes()
-    del o['seconds']
+    outcomes = result.parseoutcomes()
 
-    try:
-        del o['pytest-warnings']
-    except KeyError:
-        pass
+    for key in 'seconds', 'pytest-warnings', 'warnings', 'warning':
+        if key in outcomes:
+            del outcomes[key]
 
-    assert o == expected
+    assert outcomes == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,21 @@
 [tox]
-envlist = {py27,py34,py35,py36}-pytest_{27,28,29,32,33,34,35,36,37,38,39,40,41,42,latest}
+envlist = {py27,py35,py36}-pytest_{2,3,4},{py35,py36,py37,py38}-pytest_{50,51,52,53,54,latest}
 
 [testenv]
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 deps =
-    pytest_27: pytest>=2.7,<2.8
-    pytest_28: pytest>=2.8,<2.9
-    pytest_29: pytest>=2.9,<2.10
-    pytest_32: pytest>=3.2,<3.3
-    pytest_33: pytest>=3.3,<3.4
-    pytest_34: pytest>=3.4,<3.5
-    pytest_35: pytest>=3.5,<3.6
-    pytest_36: pytest>=3.6,<3.7
-    pytest_37: pytest>=3.7,<3.8
-    pytest_38: pytest>=3.8,<3.9
-    pytest_39: pytest>=3.9,<3.10
-    pytest_310: pytest>=3.10,<4.0
-    pytest_40: pytest>=4.0,<4.1
-    pytest_41: pytest>=4.1,<4.2
-    pytest_42: pytest>=4.2,<4.3
+    pytest_2: pytest>=2.9,<3.0
+    pytest_3: pytest>=3.10,<4.0
+    pytest_4: pytest>=4.6,<5.0
+    pytest_50: pytest>=5.0,<5.2
+    pytest_51: pytest>=5.1,<5.2
+    pytest_52: pytest>=5.2,<5.3
+    pytest_53: pytest>=5.3,<5.4
+    pytest_54: pytest>=5.4,<5.5
     pytest_latest: pytest
-commands = py.test -rw
+commands = py.test -rw {posargs}


### PR DESCRIPTION
The Tox and Travis configuration currently does not contain tests for the latest Python and pytest versions. This PR adds these new versions to the configuration. It also removes the tests for the outdated Python 3.4, and simplifies tests with pytest 2-4 by only testing with their latest minor versions, so that the test matrix does not become too excessive.